### PR TITLE
spelling improvements:  email + replacement map

### DIFF
--- a/vocode/streaming/agent/chat_gpt_agent.py
+++ b/vocode/streaming/agent/chat_gpt_agent.py
@@ -25,7 +25,7 @@ from vocode.streaming.agent.utils import (
 from vocode.streaming.models.events import Sender
 from vocode.streaming.models.transcript import Transcript
 from vocode.streaming.vector_db.factory import VectorDBFactory
-from vocode.streaming.agent.utils import replace_map_symbols
+from vocode.streaming.agent.utils import replace_map_symbols, replace_username_with_spelling_pattern
 
 TIMEOUT_SECONDS = 5
 TIMEOUT_SECONDS_BACKUP = 10
@@ -250,11 +250,10 @@ class ChatGPTAgent(RespondAgent[ChatGPTAgentConfig]):
                 logger=self.logger
             ):
                 if isinstance(message, str):
+                    # before we replace characters, such as `@`, we run the email spelling function for the regex to identify the email
+                    message = replace_username_with_spelling_pattern(message)
                     if self.agent_config.character_replacement_map:
                         message = replace_map_symbols(message, self.agent_config.character_replacement_map)
-                    if self.agent_config.remove_exclamation:
-                        # replace ! by . because it sounds better when speaking.
-                        message = message.replace('!','.')
                     if self.agent_config.add_disfluencies:
                         # artificially add disfluencies to message
                         message = make_disfluency(message)

--- a/vocode/streaming/agent/utils.py
+++ b/vocode/streaming/agent/utils.py
@@ -215,7 +215,46 @@ def replace_map_symbols(message, symbol_map):
     Returns:
     - str: The message with symbols replaced based on the provided symbol_map.
     """
-    import re
-
     pattern = re.compile("|".join(re.escape(key) for key in symbol_map.keys()))
     return pattern.sub(lambda match: symbol_map[match.group(0)], message)
+
+def replace_username_with_spelling_pattern(text) -> str:
+    """
+    Replace the username part of email addresses in the given text with a formatted pattern for the synthesized audio.
+
+    Args:
+        text (str): The input text containing email addresses.
+
+    Returns:
+        str: The text with replaced username parts according to the specified pattern.
+
+    Example:
+        >>> paragraph = "Contact me at john@example.com or support@company.com."
+        >>> result = replace_username_with_pattern(paragraph)
+        >>> print(result)
+        "Contact me at j - o - h - n @example.com or s - u - p - p - o - r - t @company.com."
+
+    The function uses a regular expression to identify email addresses in the input text. If email addresses are found,
+    it replaces the characters in the username part with a formatted pattern using the provided `format_char` function.
+
+    The `format_char` function is applied to each character in the username part to determine its formatted representation.
+    By default, it converts characters to lowercase, but you can customize this function based on specific formatting preferences.
+
+    If no email addresses are found in the input text, the function returns the original text without any replacements.
+    """
+    
+    def format_char(char):
+        return char.lower()
+    
+    def replace_chars(match):
+        username = match.group(1)
+        formatted_username = ' - '.join(format_char(char) for char in username)
+        return f'{formatted_username} @{match.group(2)}'
+    
+    email_pattern = r'\b([A-Za-z0-9._%+-]+)@([A-Za-z0-9.-]+\.[A-Z|a-z]{2,})\b'
+
+    if re.search(email_pattern, text):
+        formatted_text = re.sub(email_pattern, replace_chars, text)
+        return formatted_text
+    else:
+        return text

--- a/vocode/streaming/models/agent.py
+++ b/vocode/streaming/models/agent.py
@@ -107,7 +107,6 @@ class ChatGPTAgentConfig(AgentConfig, type=AgentType.CHAT_GPT.value):
     stop_tokens: Optional[List[str]] = ["\n"]
     frequency_penalty: float = 0.0
     cut_off_response: Optional[CutOffResponse] = None
-    remove_exclamation: bool = False
     add_disfluencies: bool = False
     azure_params: Optional[AzureOpenAIConfig] = None
     vector_db_config: Optional[VectorDBConfig] = None


### PR DESCRIPTION
- Removed `remove_exclamation: bool = False` in `ChatGPTAgentConfig`
- Email usernames are now spelled char by char. 
